### PR TITLE
Fix chap-secrets path bug

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,8 +12,10 @@ RUN git clone https://github.com/xelerance/xl2tpd.git && cd xl2tpd && make
 
 WORKDIR /usr/src/app
 
-COPY src .
+COPY src/package*.json .
 RUN npm install 
+# Run the copy in two steps to cache the npm install
+COPY src .
 
 FROM alpine
 
@@ -84,7 +86,7 @@ RUN mkdir -p /usr/src/app/secrets
 # envs for init.sh -> node communication
 ENV DYNDNS_HOST https://ns2.greyfaze.net
 ENV KEYPAIR_FILE_PATH /usr/src/app/secrets/keypair
-ENV CREDENTIALS_FILE_PATH /etc/ppp/chap-secrets
+ENV CREDENTIALS_FILE_PATH /usr/src/app/secrets/chap-secrets
 ENV VPN_IP_FILE_PATH /usr/src/app/secrets/server-ip
 ENV VPN_PSK_FILE_PATH /usr/src/app/secrets/server-psk
 ENV INTERNAL_IP_FILE_PATH /usr/src/app/secrets/internal-ip

--- a/build/src/init.sh
+++ b/build/src/init.sh
@@ -81,9 +81,9 @@ ln -s ${PWD}/secrets/ipsec.secrets /etc/ipsec.secrets
 
 # Create VPN credentials
 #   ${VPN_USER}  ${VPN_PASSWORD}
-[ ! -f "${PWD}/secrets/chap-secrets" ] &&  envsubst < "templates/chap-secrets" > "${PWD}/secrets/chap-secrets"
+[ ! -f "${CREDENTIALS_FILE_PATH}" ] &&  envsubst < "templates/chap-secrets" > "${CREDENTIALS_FILE_PATH}"
 rm /etc/ppp/chap-secrets
-ln -s ${PWD}/secrets/chap-secrets /etc/ppp/chap-secrets
+ln -s ${CREDENTIALS_FILE_PATH} /etc/ppp/chap-secrets
 
 # Output the IP for the user managment UI
 echo "WRITING PUBLIC IP TO SERVER-IP"

--- a/build/src/src/calls/createAddDevice.js
+++ b/build/src/src/calls/createAddDevice.js
@@ -5,7 +5,12 @@ const VPN_PASSWORD_LENGTH = 20;
 
 function createAddDevice(credentialsFile, generate) {
   return async function addDevice({id}) {
-    validateName(id);
+    if (id === '') {
+      throw Error('The new device name cannot be empty');
+    }
+    if (id === '#') {
+      throw Error('The new device name cannot be #');
+    }
 
     // Fetch devices data from the chap_secrets file
     let credentialsArray = await credentialsFile.fetch();
@@ -36,11 +41,6 @@ function createAddDevice(credentialsFile, generate) {
       userAction: true,
     };
   };
-}
-
-
-function validateName(newDeviceName) {
-  if (newDeviceName == '') throw Error('The new device name cannot be empty');
 }
 
 

--- a/build/src/src/dyndnsClient/getKeys.js
+++ b/build/src/src/dyndnsClient/getKeys.js
@@ -39,7 +39,11 @@ const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);
 
 function getKeys() {
-    const PATH = process.env.DEV ? './test/keypair' : process.env.KEYPAIR_FILE_PATH;
+    let PATH = process.env.DEV ? './test/keypair' : process.env.KEYPAIR_FILE_PATH;
+    if (!PATH) {
+        PATH = '/usr/src/app/secrets/keypair';
+        logs.warn('KEYPAIR_FILE_PATH is not defined. Defaulting to /usr/src/app/secrets/keypair');
+    }
     return readFile(PATH)
     .then(JSON.parse)
     .catch((err) => {

--- a/build/src/src/utils/credentialsFile.js
+++ b/build/src/src/utils/credentialsFile.js
@@ -28,17 +28,18 @@ async function fetch() {
   const fileContent = await fs.readFileSync(CREDENTIALS_FILE_PATH, 'utf-8');
 
   // Split by line breaks
-  let deviceCredentialsArray = fileContent.split(/\r?\n/);
-  // Clean empty lines if any
-  for (let i = 0; i < deviceCredentialsArray.length; i++) {
-    if (deviceCredentialsArray[i] == '') {
-      deviceCredentialsArray.splice(i, 1);
-    }
-  }
+  let deviceCredentialsArray = fileContent.trim().split(/\r?\n/);
 
   // Convert each line to an object + strip quotation marks
-  return deviceCredentialsArray.map((credentialsString) => {
-    let credentialsArray = credentialsString.split(' ');
+  return deviceCredentialsArray
+  .filter(((line) => {
+    // Ignore empty lines if any
+    if (line === '') return false;
+    if (line.startsWith('# ')) return false;
+    return true;
+  }))
+  .map((credentialsString) => {
+    let credentialsArray = credentialsString.trim().split(' ');
     return {
       name: credentialsArray[0].replace(/['"]+/g, ''),
       password: credentialsArray[2].replace(/['"]+/g, ''),


### PR DESCRIPTION
When creating a VPN for not the first time in a DAppNode, the node client got the credentials from etc/ppp/chap-secrets which is not the one in the volume therefore the credentials printed are wrong. 