### PR TITLE
Immediately register to dyndns if necessary

### DIFF
--- a/build/src/src/calls/setStaticIp.js
+++ b/build/src/src/calls/setStaticIp.js
@@ -1,4 +1,5 @@
 const db = require('../db');
+const dyndnsClient = require('../dyndnsClient');
 
 async function setStaticIp({staticIp}) {
     const oldStaticIp = db.get('staticIp').value();
@@ -10,6 +11,11 @@ async function setStaticIp({staticIp}) {
         message = `Enabled static IP: ${staticIp}`;
     } else if (oldStaticIp && !staticIp) {
         message = `Disabled static IP`;
+        // If the staticIp is being disabled but there is no keypair: register to dyndns
+        if (!db.get('keypair').value()) {
+            await dyndnsClient.updateIp();
+            message += `, and registered to dyndns: ${db.get('domain').value()}`;
+        }
     } else {
         message = `Updated static IP: ${staticIp}`;
     }

--- a/build/src/src/dyndnsClient/getKeys.js
+++ b/build/src/src/dyndnsClient/getKeys.js
@@ -25,17 +25,20 @@ const db = require('../db');
 
 // dyndnsHost has to be stripped of http(s):// tag
 // process.env.DYNDNS_HOST should include said tag
-const {DYNDNS_HOST} = process.env;
-const dyndnsHost = DYNDNS_HOST && DYNDNS_HOST.includes('://')
-    ? DYNDNS_HOST.split('://')[1]
-    : DYNDNS_HOST;
+function getDyndnsHost() {
+    const {DYNDNS_HOST} = process.env;
+    return DYNDNS_HOST && DYNDNS_HOST.includes('://')
+        ? DYNDNS_HOST.split('://')[1]
+        : DYNDNS_HOST;
+}
+
 
 function generateKeys() {
     const identity = EthCrypto.createIdentity();
     const subdomain = identity.address.toLowerCase().substr(2).substring(0, 16);
     return {
         ...identity,
-        domain: subdomain+'.'+dyndnsHost,
+        domain: subdomain+'.'+getDyndnsHost(),
     };
 }
 

--- a/build/src/test/fetchVpnParameters/index.test.js
+++ b/build/src/test/fetchVpnParameters/index.test.js
@@ -75,7 +75,7 @@ describe('fetchVpnParameters test', function() {
     });
   });
 
-  it('should call log adminCredentials', async () => {
+  it('should call log adminCredentials, and contain the static IP', async () => {
     const credentialsFile = require('../../src/utils/credentialsFile');
     const credentialsArray = [
       {name: 'SUPERadmin', password: 'MockPass2', ip: '172.33.10.1'},
@@ -107,12 +107,13 @@ describe('fetchVpnParameters test', function() {
     });
   });
 
-  it('should call log adminCredentials', async () => {
+  it('should call log adminCredentials, and contain the dyndns domain', async () => {
     const credentialsFile = require('../../src/utils/credentialsFile');
     const credentialsArray = [
       {name: 'SUPERadmin', password: 'MockPass2', ip: '172.33.10.1'},
     ];
     await credentialsFile.write(credentialsArray);
+    console.log(db.getState());
     const log = await logAdminCredentials();
     expect(log).to.include('.dyn.test.io');
   });


### PR DESCRIPTION
Now, if you install a DAppNode with a static IP and then disable it, you should the message: 
```
"Disabled static IP, and registered to dyndns: 1234abcd1234abcd.dyndns.domain"
```
after executing the call that disabled the static IP.