### PR TITLE
Dyndns review

### DIFF
--- a/build/src/src/dyndnsClient/checkIpAndUpdateIfNecessary.js
+++ b/build/src/src/dyndnsClient/checkIpAndUpdateIfNecessary.js
@@ -1,0 +1,62 @@
+const updateIp = require("./updateIp");
+const db = require("../db");
+const logs = require("../logs.js")(module);
+const lookup = require("../utils/lookup");
+const getExternalUpnpIp = require("../utils/getExternalUpnpIp");
+const getPublicIpFromUrls = require("../utils/getPublicIpFromUrls");
+
+/**
+ * DynDNS interval check
+ * If the static is not defined, register and update the DynDNS registry
+ *
+ * Before doing so, it will check if it is actually necessary:
+ * 1. Get its own IP and check if has changed from its internal DB record
+ *    - If UPNP is available fetch the IP from there
+ *    - Otherwise, fetch the IP from a centralized source
+ * 2. Query the DynDNS and check if the record matches the server's IP
+ *
+ * If all queries were successful and all looks great skip update.
+ * On any doubt, update the IP
+ *
+ * @returns {bool} should update
+ */
+async function shouldUpdate() {
+  try {
+    const ipPrevious = await db.get("ip");
+    let ip;
+    const upnpAvailable = await db.get("upnpAvailable");
+    if (upnpAvailable) ip = await getExternalUpnpIp();
+    if (!ip) ip = await getPublicIpFromUrls();
+    // Store the IP on cache
+    if (ip) await db.set("ip", ip);
+    // If there was an error fetching the IP or it change, update it
+    if (!ip || ip !== ipPrevious) return true;
+
+    /**
+     * Check that the IP in the server is correct
+     * - On the first run, this lookup will fail because the VPN has
+     *   not registered itself yet to the DynDNS
+     * - This check will detect if the DynDNS loses its DB because
+     *   it was corrupted or some other problem
+     */
+    const domain = await db.get("domain");
+    const ipDyndns = await lookup(domain, { ignoreErrors: true });
+    // If there was an error fetching the IP or it change, update it
+    if (!ipDyndns || ipDyndns !== ip) return true;
+
+    // If all good, don't update
+    return false;
+  } catch (e) {
+    // in case of error, should update
+    logs.warn(`Error on shouldUpdate: ${e.stack}`);
+    return true;
+  }
+}
+
+async function checkIpAndUpdateIfNecessary() {
+  if (await shouldUpdate()) {
+    await updateIp();
+  }
+}
+
+module.exports = checkIpAndUpdateIfNecessary;

--- a/build/src/src/dyndnsClient/index.js
+++ b/build/src/src/dyndnsClient/index.js
@@ -1,7 +1,9 @@
 const updateIp = require("./updateIp");
 const generateKeys = require("./generateKeys");
+const checkIpAndUpdateIfNecessary = require("./checkIpAndUpdateIfNecessary");
 
 module.exports = {
   updateIp,
-  generateKeys
+  generateKeys,
+  checkIpAndUpdateIfNecessary
 };

--- a/build/src/src/utils/lookup.js
+++ b/build/src/src/utils/lookup.js
@@ -1,0 +1,28 @@
+const { promisify } = require("util");
+const dns = require("dns");
+const lookupAsync = promisify(dns.lookup);
+
+/**
+ * Does a dns.lookup to resolve a hostname
+ * Usage:
+ *   `await lookup("ipfs.io")` > "209.94.90.1"
+ *
+ * @param {string} hostname = "ipfs.io"
+ * @param {object} options, available options:
+ * - ignoreErrors: {bool}. If true, on error doesn't log anything
+ *   and returns null
+ * @returns {string} address = "209.94.90.1"
+ *
+ *  Error: getaddrinfo EAI_AGAIN
+ */
+async function lookup(hostname, { ignoreErrors }) {
+  try {
+    const { address } = await lookupAsync(hostname);
+    return address;
+  } catch (e) {
+    if (ignoreErrors) return null;
+    else throw e;
+  }
+}
+
+module.exports = lookup;

--- a/build/src/test/dyndnsClient/checkIpAndUpdateIfNecessary.test.js
+++ b/build/src/test/dyndnsClient/checkIpAndUpdateIfNecessary.test.js
@@ -1,0 +1,86 @@
+const proxyquire = require("proxyquire");
+const chai = require("chai");
+const expect = require("chai").expect;
+const sinon = require("sinon");
+
+chai.should();
+
+function importModule({
+  updateIp,
+  db,
+  lookup,
+  getExternalUpnpIp,
+  getPublicIpFromUrls
+}) {
+  return proxyquire("../../src/dyndnsClient/checkIpAndUpdateIfNecessary", {
+    "./updateIp": updateIp,
+    "../db": db,
+    "../utils/lookup": lookup,
+    "../utils/getExternalUpnpIp": getExternalUpnpIp,
+    "../utils/getPublicIpFromUrls": getPublicIpFromUrls
+  });
+}
+function dbFactory(_db) {
+  return {
+    get: async key => _db[key],
+    set: async (key, val) => (_db[key] = val)
+  };
+}
+
+describe("Call function: addDevice", function() {
+  it("should NOT call update on a regular case", async () => {
+    const ip = "85.84.83.82";
+    const updateIp = sinon.stub().resolves();
+    const checkIpAndUpdateIfNecessary = importModule({
+      updateIp,
+      db: dbFactory({ ip, domain: "my.domain" }),
+      lookup: async () => ip,
+      getExternalUpnpIp: async () => ip,
+      getPublicIpFromUrls: async () => ip
+    });
+
+    await checkIpAndUpdateIfNecessary();
+
+    sinon.assert.notCalled(updateIp);
+  });
+
+  it("should CALL update if the IP changes", async () => {
+    const ip = "85.84.83.82";
+    const newIp = "200.1.2.1";
+    const _db = { ip, domain: "my.domain" };
+    const updateIp = sinon.stub().resolves();
+    const checkIpAndUpdateIfNecessary = importModule({
+      updateIp,
+      db: dbFactory(_db),
+      lookup: async () => ip,
+      getExternalUpnpIp: async () => null,
+      getPublicIpFromUrls: async () => newIp
+    });
+
+    await checkIpAndUpdateIfNecessary();
+
+    sinon.assert.calledOnce(updateIp);
+    expect(_db.ip).to.equal(newIp);
+  });
+
+  it("should CALL update if the DynDNS record gets corrupt", async () => {
+    const ip = "85.84.83.82";
+    const corruptIp = "200.1.2.1";
+    const domain = "my.domain";
+    const updateIp = sinon.stub().resolves();
+    const lookup = sinon.stub().resolves(corruptIp);
+    const checkIpAndUpdateIfNecessary = importModule({
+      updateIp,
+      db: dbFactory({ ip, domain }),
+      lookup,
+      getExternalUpnpIp: async () => null,
+      getPublicIpFromUrls: async () => ip
+    });
+
+    await checkIpAndUpdateIfNecessary();
+
+    sinon.assert.calledOnce(updateIp);
+    sinon.assert.calledOnce(lookup);
+    sinon.assert.calledWith(lookup, domain);
+  });
+});


### PR DESCRIPTION
Refactor the DynDNS interval check:

If the static is not defined, register and update the DynDNS registry

Before doing so, it will check if it is actually necessary:
- Get its own IP and check if has changed from its internal DB record
  - If UPNP is available fetch the IP from there
  - Otherwise, fetch the IP from a centralized source
- Query the DynDNS and check if the record matches the server's IP

*Note*: On the first run the DNS lookup will fail and that will trigger the update

If all queries were successful and all looks great skip update.
On any doubt, update the IP

Will solve - https://github.com/dappnode/DNP_VPN/issues/118 (using a keyword to not trigger a close)