### PR TITLE
Authorize JSON RPC client with a token

### DIFF
--- a/build/src/src/api/auth.ts
+++ b/build/src/src/api/auth.ts
@@ -1,9 +1,10 @@
+import fs from "fs";
 import express from "express";
 import { logs } from "../logs";
+import { getRandomToken } from "../utils/crypto";
+import { RPC_TOKEN_PATH, RPC_TOKEN_HEADER } from "../params";
 
 const allowAllIps = Boolean(process.env.ALLOW_ALL_IPS);
-
-if (allowAllIps) logs.warn(`WARNING! ALLOWING ALL IPFS`);
 
 // Authorize by IP
 
@@ -33,14 +34,30 @@ function isLocalhostIp(ip: string): boolean {
   return allowAllIps || localhostIps.some(_ip => ip.includes(_ip));
 }
 
-export const isAdmin: express.RequestHandler = (req, res, next) => {
-  const ip = req.ip;
-  if (isAdminIp(ip)) next();
-  else res.status(403).send(`Requires admin permission. Forbidden ip: ${ip}`);
-};
+/**
+ * Initializes auth handlers with a random local token
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export function getAuthHandlers() {
+  if (allowAllIps) logs.warn(`WARNING! ALLOWING ALL IPFS`);
+  if (!fs.existsSync(RPC_TOKEN_PATH))
+    fs.writeFileSync(RPC_TOKEN_PATH, getRandomToken());
+  const rpcToken = fs.readFileSync(RPC_TOKEN_PATH, "utf8");
 
-export const isLocalhost: express.RequestHandler = (req, res, next) => {
-  const ip = req.ip;
-  if (isLocalhostIp(ip)) next();
-  else res.status(403).send(`Only localhost. Forbidden ip: ${ip}`);
-};
+  const isAdmin: express.RequestHandler = (req, res, next) => {
+    const ip = req.ip;
+    if (isAdminIp(ip) || req.header(RPC_TOKEN_HEADER) === rpcToken) next();
+    else res.status(403).send(`Requires admin permission. Forbidden ip: ${ip}`);
+  };
+
+  const isLocalhost: express.RequestHandler = (req, res, next) => {
+    const ip = req.ip;
+    if (isLocalhostIp(ip)) next();
+    else res.status(403).send(`Only localhost. Forbidden ip: ${ip}`);
+  };
+
+  return {
+    isAdmin,
+    isLocalhost
+  };
+}

--- a/build/src/src/api/getRpcCall.ts
+++ b/build/src/src/api/getRpcCall.ts
@@ -1,18 +1,50 @@
+import fs from "fs";
+import url from "url";
 import got from "got";
 import { Routes, routesData } from "../api/routes";
 import { mapValues } from "lodash";
 import { Args, Result } from "../types";
+import {
+  RPC_TOKEN_HEADER,
+  VPN_DNP_IP,
+  API_PORT,
+  RPC_TOKEN_PATH
+} from "../params";
 
 interface RpcResponse {
   result?: Result;
   error?: { code: number; message: string; data: string };
 }
 
-export function getRpcCall(vpnApiRpcUrl: string): Routes {
+/**
+ * Get an authorized JSON RPC client for the VPN API
+ * Works calling from inside the same container as the VPN and from a separate
+ * container as long as the rpcToken is available in both contexts
+ */
+export function getVpnRpcApiClient(): Routes {
+  const vpnRpcApiUrl = url.format({
+    protocol: "http",
+    hostname: VPN_DNP_IP,
+    port: API_PORT,
+    pathname: "rpc"
+  });
+  const rpcToken = fs.readFileSync(RPC_TOKEN_PATH, "utf8");
+  return getRpcCall(vpnRpcApiUrl, rpcToken);
+}
+
+/**
+ * Call an external JSON RPC endpoint
+ * @param vpnApiRpcUrl "http://localhost:3000/rpc"
+ * @param rpcToken "8721944069..."
+ */
+export function getRpcCall(vpnApiRpcUrl: string, rpcToken: string): Routes {
   return mapValues(routesData, (_0, route) => {
     return async function(...args: Args): Promise<Result> {
       const body = await got
-        .post(vpnApiRpcUrl, { json: { method: route, params: args } })
+        .post(vpnApiRpcUrl, {
+          json: { method: route, params: args },
+          headers: { [RPC_TOKEN_HEADER]: rpcToken }
+        })
         .json<RpcResponse>();
 
       // RPC response are always code 200

--- a/build/src/src/api/index.ts
+++ b/build/src/src/api/index.ts
@@ -2,9 +2,8 @@ import express from "express";
 import * as methods from "../calls";
 import { getRpcHandler } from "./getRpcHandler";
 import { logs } from "../logs";
-import { LoggerMiddleware } from "../types";
 import { wrapHandler } from "./utils";
-import { isAdmin, isLocalhost } from "./auth";
+import { getAuthHandlers } from "./auth";
 import { clientConnect } from "./clientConnect";
 import { CLIENT_CONNECT_PATHNAME } from "../params";
 
@@ -17,13 +16,12 @@ import { CLIENT_CONNECT_PATHNAME } from "../params";
 export function startHttpApi(port: number): void {
   const app = express();
 
-  // RPC
-  const routesLogger: LoggerMiddleware = {
+  const rpcHandler = getRpcHandler(methods, {
     onCall: (method, args) => logs.debug(`RPC call ${method}`, args || []),
     onSuccess: (method, result) => logs.debug(`RPC success ${method}`, result),
     onError: (method, e) => logs.error(`RPC error ${method}`, e)
-  };
-  const rpcHandler = getRpcHandler(methods, routesLogger);
+  });
+  const { isAdmin, isLocalhost } = getAuthHandlers();
 
   app.use(express.json());
 

--- a/build/src/src/getAdminCredentials.ts
+++ b/build/src/src/getAdminCredentials.ts
@@ -11,22 +11,22 @@
 // 2. Wait for MASTER_ADMIN user to exist
 // 3. Get the MASTER_ADMIN user URL to connect
 // 4. Print a nicely formated msg with a QR code
+//
+// This script is run by this command
+// alias dappnode_connect='docker run --rm \
+//   -v dncore_vpndnpdappnodeeth_data:/usr/src/app/secrets \
+//   $(docker inspect DAppNodeCore-vpn.dnp.dappnode.eth --format '{{.Config.Image}}') \
+//   getAdminCredentials'
+//
 
-import url from "url";
-import { getRpcCall } from "./api/getRpcCall";
-import { API_PORT, MASTER_ADMIN_NAME } from "./params";
+import { getVpnRpcApiClient } from "./api/getRpcCall";
+import { MASTER_ADMIN_NAME } from "./params";
 import { renderQrCode } from "./utils/renderQrCode";
 
 /* eslint-disable no-console */
 
 const statusTimeout = 60 * 1000;
-const vpnRpcApiUrl = url.format({
-  protocol: "http",
-  hostname: "127.0.0.1",
-  port: API_PORT,
-  pathname: "rpc"
-});
-const api = getRpcCall(vpnRpcApiUrl);
+const api = getVpnRpcApiClient();
 
 // ### TODO: Is this still necessary?
 process.on("SIGINT", () => process.exit(128));

--- a/build/src/src/params.ts
+++ b/build/src/src/params.ts
@@ -26,6 +26,9 @@ export const CLIENT_CONNECT_PATHNAME = "/client-connect";
 export const OPENVPN_CRED_PORT = 8092;
 export const CRED_URL_QUERY_PARAM = "id";
 export const CRED_URL_PATHNAME = "/cred";
+export const RPC_TOKEN_PATH = "/usr/src/app/secrets/rpc-token";
+export const RPC_TOKEN_HEADER = "token";
+export const VPN_DNP_IP = "172.33.1.4";
 
 // Global ENVs names
 export const GLOBAL_ENVS = {

--- a/build/src/src/vpncli.ts
+++ b/build/src/src/vpncli.ts
@@ -1,22 +1,14 @@
 #!/usr/bin/env node
 
 import yargs, { CommandBuilder } from "yargs";
-import url from "url";
 import chalk from "chalk";
 import prettyjson from "prettyjson";
-import { getRpcCall } from "./api/getRpcCall";
-import { API_PORT } from "./params";
+import { getVpnRpcApiClient } from "./api/getRpcCall";
 
 /* eslint-disable no-console */
 
-const vpnRpcApiUrl = url.format({
-  protocol: "http",
-  hostname: "127.0.0.1",
-  port: API_PORT,
-  pathname: "rpc"
-});
 // Initialize an RPC client connecting to the VPN RPC server
-const api = getRpcCall(vpnRpcApiUrl);
+const api = getVpnRpcApiClient();
 
 const idArg: CommandBuilder<{}, { id: string }> = yargs =>
   yargs.positional("id", {


### PR DESCRIPTION
When the main VPN NodeJS process starts creates a random token in `/usr/src/app/secrets/rpc-token`
Any request that contains that token will be authorized as admin. This means that we can still run the `getAdminCredentials` and `vpncli` scripts in a separate container with `docker run` if the mount the secrets volume `-v dncore_vpndnpdappnodeeth_data:/usr/src/app/secrets`. This architecture should work as well by doing a `docker exec`, since the token will be equally available.

**Edit**: This approach won't work unless the second container joins the dappnode network, which defeats the main purpose of this PR