### PR TITLE
Print friendlier messages when DAppNode initialization is slow

### DIFF
--- a/build/src/src/calls/getStatus.ts
+++ b/build/src/src/calls/getStatus.ts
@@ -1,8 +1,8 @@
-import { vpnStatus } from "../config";
+import { config } from "../config";
 import { VpnStatus } from "../types";
 
 /**
  * Returns the current status of the VPN server
  * See vpnStatus type for more info
  */
-export const getStatus = async (): Promise<VpnStatus> => vpnStatus;
+export const getStatus = async (): Promise<VpnStatus> => config.vpnStatus;

--- a/build/src/src/config.ts
+++ b/build/src/src/config.ts
@@ -8,6 +8,7 @@ import { VpnStatus } from "./types";
 export const config: {
   hostname?: string;
   internalIp?: string;
-} = {};
-
-export const vpnStatus: VpnStatus = { status: "STARTED" };
+  vpnStatus: VpnStatus;
+} = {
+  vpnStatus: { status: "STARTED" }
+};

--- a/build/src/src/index.ts
+++ b/build/src/src/index.ts
@@ -5,7 +5,7 @@ import { startCredentialsWebserver } from "./credentials";
 import { API_PORT, OPENVPN_CRED_PORT, MASTER_ADMIN_NAME } from "./params";
 import { pollDappnodeConfig } from "./pollDappnodeConfig";
 import { initalizeOpenVpnConfig, openvpnBinary } from "./openvpn";
-import { config, vpnStatus } from "./config";
+import { config } from "./config";
 import { startCredentialsService } from "./credentials";
 import { logs } from "./logs";
 
@@ -24,19 +24,22 @@ startCredentialsService();
 // Configure and start VPN client
 (async function startVpnClient(): Promise<void> {
   try {
-    vpnStatus.status = "FETCHING_CONFIG";
+    config.vpnStatus = { status: "FETCHING_CONFIG" };
     const { hostname, internalIp } = await pollDappnodeConfig({
       onRetry: (errorMsg, retryCount) => {
-        vpnStatus.status = "FETCHING_CONFIG_ERROR";
-        vpnStatus.msg = `#${retryCount} - ${errorMsg}`;
-        logs.info(`Fetching config retry: ${vpnStatus.msg}`);
+        config.vpnStatus = {
+          status: "FETCHING_CONFIG_ERROR",
+          retryCount,
+          msg: errorMsg
+        };
+        logs.info(`Fetching config retry ${retryCount}: ${errorMsg}`);
       }
     });
     config.hostname = hostname;
     config.internalIp = internalIp;
 
     logs.info("Initializing OpenVPN config", { hostname, internalIp });
-    vpnStatus.status = "INITIALIZING";
+    config.vpnStatus = { status: "INITIALIZING" };
     await initalizeOpenVpnConfig({ hostname, internalIp });
 
     try {
@@ -45,7 +48,7 @@ startCredentialsService();
       logs.error(`Error creating ${MASTER_ADMIN_NAME} device`, e);
     }
 
-    vpnStatus.status = "READY";
+    config.vpnStatus = { status: "READY" };
     openvpnBinary.restart();
   } catch (e) {
     logs.error("Error starting VPN", e);

--- a/build/src/src/params.ts
+++ b/build/src/src/params.ts
@@ -53,3 +53,11 @@ export const GLOBAL_ENVS_KEYS: { [K in keyof typeof GLOBAL_ENVS]: K } = {
   PUBLIC_IP: "PUBLIC_IP",
   SERVER_NAME: "SERVER_NAME"
 };
+
+// Internal error messages
+/**
+ * This error happens when the config is polled from the DAPPMANAGER which is
+ * already active but has not completed the initializeDb process. When this error
+ * happens show OK messages to the user since it's an expected situation
+ */
+export const NO_HOSTNAME_RETURNED_ERROR = "No hostname returned";

--- a/build/src/src/pollDappnodeConfig.ts
+++ b/build/src/src/pollDappnodeConfig.ts
@@ -4,7 +4,8 @@ import retry from "async-retry";
 import {
   dappmanagerApiUrlGlobalEnvs,
   GLOBAL_ENVS_KEYS,
-  GLOBAL_ENVS
+  GLOBAL_ENVS,
+  NO_HOSTNAME_RETURNED_ERROR
 } from "./params";
 import { isDomain } from "./utils/domain";
 import { logs } from "./logs";
@@ -47,7 +48,7 @@ export async function pollDappnodeConfig({
         .text()
         .then(res => res.trim())
         .then(data => {
-          if (!data) throw Error("No hostname returned");
+          if (!data) throw Error(NO_HOSTNAME_RETURNED_ERROR);
           if (!ip.isV4Format(data) && !isDomain(data))
             throw Error(`Invalid hostname returned: ${data}`);
           return data;

--- a/build/src/src/types.ts
+++ b/build/src/src/types.ts
@@ -6,6 +6,7 @@ export interface VpnStatus {
     | "INITIALIZING"
     | "READY";
   msg?: string | undefined;
+  retryCount?: number;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Changes on logging when calling `dappnode_connect`:

1. The same `error.message` will only be printed once. The error message is tracked, and if it's repeated the script will just print a `.` (dot) without new line.
2. When the DAPPMANAGER is polled for the domain and external IP; if the DAPPMANAGER is still initializing it will return an empty hostname. Catch that specific error named as `NO_HOSTNAME_RETURNED_ERROR` and just print `Initializing DAppNode...` instead of the previous error message:
```
retry #2 - VPN not ready, status: FETCHING_CONFIG_ERROR #2 - No hostname returned
```