### PR TITLE
Persist internalIP

### DIFF
--- a/build/src/src/pollDappnodeConfig.ts
+++ b/build/src/src/pollDappnodeConfig.ts
@@ -24,12 +24,19 @@ export async function pollDappnodeConfig({
   hostname: string;
   internalIp: string;
 }> {
-  // If ENVs are already available, do not poll
-  const hostnameFromEnv = process.env[GLOBAL_ENVS.HOSTNAME];
-  const internalIpFromEnv = process.env[GLOBAL_ENVS.INTERNAL_IP];
-  if (hostnameFromEnv && internalIpFromEnv)
-    return { hostname: hostnameFromEnv, internalIp: internalIpFromEnv };
+  // If ENVs are already available, do not poll (only for hostname?)
+  const hostname =
+    process.env[GLOBAL_ENVS.HOSTNAME] || (await getHostname({ onRetry }));
+  const internalIp = await getInternalIp();
 
+  return { hostname: hostname, internalIp: internalIp };
+}
+
+async function getHostname({
+  onRetry
+}: {
+  onRetry: (errorMsg: string, retryCount: number) => void;
+}) {
   // Add async-retry in case the DAPPMANAGER returns an 200 code with empty hostname
   const hostname = await retry(
     () =>
@@ -60,7 +67,10 @@ export async function pollDappnodeConfig({
       }
     }
   );
+  return hostname;
+}
 
+async function getInternalIp() {
   // internal IP is an optional feature for when NAT-Loopback is off
   try {
     const internalIp = await got(GLOBAL_ENVS_KEYS.INTERNAL_IP, {
@@ -70,9 +80,10 @@ export async function pollDappnodeConfig({
       .text()
       .then(res => res.trim());
 
-    return { hostname, internalIp };
+    return internalIp;
   } catch (e) {
     logs.warn(`Error getting internal IP from DAPPMANAGER`, e);
-    return { hostname, internalIp: "" };
+    // InternalIp=""
+    return "";
   }
 }


### PR DESCRIPTION
**Changes**
1. Splitted functionality in two new functions: **getHostname()** and **getInternalIp()**
2. Persist in api call for internalIP.