### PR TITLE
compose migration from 3.4 to 3.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.4"
+version: "3.5"
 networks:
   dncore_network:
     name: dncore_network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,33 +1,33 @@
-version: '3.4'
+version: "3.4"
 networks:
-  network:
-    driver: bridge
-    ipam:
-      config:
-        - subnet: 172.33.0.0/16
+  dncore_network:
+    name: dncore_network
+    external: true
 volumes:
   vpndnpdappnodeeth_data: {}
   vpndnpdappnodeeth_config: {}
 services:
   vpn.dnp.dappnode.eth:
     build: .
-    image: 'vpn.dnp.dappnode.eth:0.2.8'
+    image: "vpn.dnp.dappnode.eth:0.2.8"
     container_name: DAppNodeCore-vpn.dnp.dappnode.eth
     privileged: true
     restart: always
     volumes:
-      - '/var/run/docker.sock:/var/run/docker.sock'
-      - '/etc/hostname:/etc/vpnname:ro'
-      - '/usr/src/dappnode/config:/usr/src/app/config:ro'
-      - '/lib/modules:/lib/modules:ro'
-      - 'vpndnpdappnodeeth_data:/usr/src/app/secrets'
-      - 'vpndnpdappnodeeth_config:/etc/openvpn'
+      - "/var/run/docker.sock:/var/run/docker.sock"
+      - "/etc/hostname:/etc/vpnname:ro"
+      - "/usr/src/dappnode/config:/usr/src/app/config:ro"
+      - "/lib/modules:/lib/modules:ro"
+      - "vpndnpdappnodeeth_data:/usr/src/app/secrets"
+      - "vpndnpdappnodeeth_config:/etc/openvpn"
     ports:
-      - '1194:1194/udp'
-      - '8092:8092'
+      - "1194:1194/udp"
+      - "8092:8092"
     dns: 172.33.1.2
     networks:
-      network:
+      dncore_network:
         ipv4_address: 172.33.1.4
+        aliases:
+          - vpn.dappnode
     logging:
       driver: journald


### PR DESCRIPTION
- Set `dncore_network` as external (will be asumme as created. The installer should create at installation https://github.com/dappnode/DAppNode_Installer/pull/98)
- Add alias

More info in https://github.com/dappnode/DNP_DAPPMANAGER/issues/655