### PR TITLE
change restart policy to unless-stopped

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     image: "vpn.dnp.dappnode.eth:0.2.8"
     container_name: DAppNodeCore-vpn.dnp.dappnode.eth
     privileged: true
-    restart: always
+    restart: unless-stopped
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
       - "/etc/hostname:/etc/vpnname:ro"


### PR DESCRIPTION
the VPN package should change its restart policy to unless-stopped, so users could stop it in the UI

After this PR the dappmanager should allow to manually stop this core package (as it does now for the wifi)