### PR TITLE
Add localhost as an additional connection target in client config

### DIFF
--- a/bin/ovpn_getclient
+++ b/bin/ovpn_getclient
@@ -39,6 +39,9 @@ remote-cert-tls server
 
 remote $OVPN_HOSTNAME $OVPN_PORT $OVPN_PROTO"
 
+    # Always include localhost as an additional connection target
+    echo "remote localhost $OVPN_PORT $OVPN_PROTO"
+
     if [ -n "$DAPPNODE_INTERNAL_IP" ]; then
         echo "remote $DAPPNODE_INTERNAL_IP $OVPN_PORT $OVPN_PROTO"
     fi


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

Adds localhost as an additional connection target in the client configuration to enhance connectivity options.

**How can be tested?**

> Test the connection by attempting to connect to the VPN using localhost as the target. Verify that the connection is established successfully.



